### PR TITLE
TEST: Add DataUpdateServiceDefault to GettingStartedOnPrem pipeline example

### DIFF
--- a/console/src/main/java/fiftyone/ipintelligence/examples/console/GettingStartedOnPrem.java
+++ b/console/src/main/java/fiftyone/ipintelligence/examples/console/GettingStartedOnPrem.java
@@ -49,10 +49,9 @@ import fiftyone.ipintelligence.shared.IPIntelligenceData;
 import fiftyone.pipeline.core.configuration.PipelineOptions;
 import fiftyone.pipeline.core.configuration.PipelineOptionsFactory;
 import fiftyone.pipeline.core.data.FlowData;
-import fiftyone.pipeline.core.data.IWeightedValue;
 import fiftyone.pipeline.core.flowelements.Pipeline;
-import fiftyone.pipeline.engines.data.AspectPropertyValue;
 import fiftyone.pipeline.engines.fiftyone.flowelements.FiftyOnePipelineBuilder;
+import fiftyone.pipeline.engines.services.DataUpdateServiceDefault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -146,6 +145,7 @@ public class GettingStartedOnPrem {
         PipelineOptions pipelineOptions = PipelineOptionsFactory.getOptionsFromFile(optionsFile);
         // Build a new Pipeline from the configuration.
         try (Pipeline pipeline = new FiftyOnePipelineBuilder()
+                .addService(new DataUpdateServiceDefault())
                 .buildFromConfiguration(pipelineOptions)) {
 
 


### PR DESCRIPTION
Fix error: Data update service is required but does not exist. The data update service is needed when automatic updates or file system watcher is enabled.