### PR TITLE
Align resource key and data file environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ Cloud examples need a resource key. The key is read from the
 `51DEGREES_RESOURCE_KEY` environment variable or system property first. The
 legacy `TestResourceKey` name is still supported and is checked second.
 
+The cloud property tiers changed in May 2026. The examples and this
+documentation now reflect what is free and what needs a paid subscription.
+
+- Free tier IP properties are Country, LocationConfidence, Ip and IpV6.
+- Paid IP properties used by the examples are CountryCode, CountryCode3,
+  Region, State, Town, TimeZoneOffset, RegisteredName, RegisteredOwner,
+  RegisteredCountry, IpRangeStart, IpRangeEnd, Latitude, Longitude, Areas
+  and AccuracyRadiusMin.
+
+A free resource key selecting the free tier properties can be created at
+https://configure.51degrees.com/Wkqxf3Bs. A resource key that also includes
+the paid properties used by the examples can be created at
+https://configure.51degrees.com/hYzn3TV3. See https://51degrees.com/pricing
+to get a paid subscription with more properties.
+
 ### On-Premise
 
 | Example                  | Description                                                                                                                                                                                                                    |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ ip-intelligence-java-examples/
 └── shared/
 ```
 
+The examples locate the data file in the following order:
+
+1. The `51DEGREES_IPI_PATH` environment variable or system property, which can
+   be set to an explicit path to the data file.
+2. A search of the project folder hierarchy for the expected file name.
+3. The expected location `ip-intelligence-data/51Degrees-EnterpriseIpiV41.ipi`
+   (the configuration files for the getting started examples fall back to the
+   free Lite file `ip-intelligence-data/51Degrees-LiteV41.ipi`).
+
 This project contains sub-modules - **console**, giving examples that are intended
 to be run from the command line/console and **web**, illustrating use
 of 51Degrees Web/Servlet integration. There is also a **shared** sub-module
@@ -44,6 +53,10 @@ The table below describes the examples available in this repository.
 ### Cloud (coming soon)
 
 Cloud examples will be added once the Cloud service for IP Intelligence becomes available.
+
+Cloud examples need a resource key. The key is read from the
+`51DEGREES_RESOURCE_KEY` environment variable or system property first. The
+legacy `TestResourceKey` name is still supported and is checked second.
 
 ### On-Premise
 

--- a/console/src/main/java/fiftyone/ipintelligence/examples/console/GettingStartedMixed.java
+++ b/console/src/main/java/fiftyone/ipintelligence/examples/console/GettingStartedMixed.java
@@ -126,7 +126,9 @@ public class GettingStartedMixed {
             System.setProperty("TestDataFile", ipiLocation);
         } catch (Exception e) {
             logger.error("Failed to find IP Intelligence data file at '{}'. " +
-                    "Please provide a valid path to an IP Intelligence data file (.ipi).", ipiDataFile);
+                    "Please provide a valid path to an IP Intelligence data file (.ipi). " +
+                    "An explicit path can be supplied via the {} environment variable.",
+                    ipiDataFile, DataFileHelper.IPI_PATH_ENV_VAR);
             throw e;
         }
 

--- a/console/src/main/java/fiftyone/ipintelligence/examples/console/GettingStartedOnPrem.java
+++ b/console/src/main/java/fiftyone/ipintelligence/examples/console/GettingStartedOnPrem.java
@@ -128,8 +128,10 @@ public class GettingStartedOnPrem {
         } catch (Exception e) {
             logger.error("Failed to find IP Intelligence data file at '{}'. " +
                     "Please provide a valid path to an IP Intelligence data file (.ipi). " +
+                    "An explicit path can be supplied via the {} environment variable. " +
                     "For testing, you can obtain an enterprise data file by contacting us at " +
-                    "https://51degrees.com/contact-us", dataFile);
+                    "https://51degrees.com/contact-us",
+                    dataFile, DataFileHelper.IPI_PATH_ENV_VAR);
             throw e;
         }
 

--- a/console/src/main/java/fiftyone/ipintelligence/examples/console/MetadataOnPrem.java
+++ b/console/src/main/java/fiftyone/ipintelligence/examples/console/MetadataOnPrem.java
@@ -79,7 +79,9 @@ public class MetadataOnPrem {
             dataFileLocation = DataFileHelper.getDataFileLocation(dataFile);
         } catch (Exception e) {
             logger.error("Failed to find IP Intelligence data file at '{}'. " +
-                    "Please provide a valid path to an IP Intelligence data file (.ipi).", dataFile);
+                    "Please provide a valid path to an IP Intelligence data file (.ipi). " +
+                    "An explicit path can be supplied via the {} environment variable.",
+                    dataFile, DataFileHelper.IPI_PATH_ENV_VAR);
             throw e;
         }
         // Build a new on-premise IP Intelligence engine with the max performance profile.

--- a/console/src/main/java/fiftyone/ipintelligence/examples/console/OfflineProcessing.java
+++ b/console/src/main/java/fiftyone/ipintelligence/examples/console/OfflineProcessing.java
@@ -130,7 +130,9 @@ public class OfflineProcessing {
             detectionFile = DataFileHelper.getDataFileLocation(dataFile);
         } catch (Exception e) {
             logger.error("Failed to find IP Intelligence data file at '{}'. " +
-                    "Please provide a valid path to an IP Intelligence data file (.ipi).", dataFile);
+                    "Please provide a valid path to an IP Intelligence data file (.ipi). " +
+                    "An explicit path can be supplied via the {} environment variable.",
+                    dataFile, DataFileHelper.IPI_PATH_ENV_VAR);
             throw e;
         }
 

--- a/console/src/main/resources/tacCloud.xml
+++ b/console/src/main/resources/tacCloud.xml
@@ -24,13 +24,12 @@
     <Elements>
         <Element>
             <BuildParameters>
-                <!-- TAC lookup and Native Model are not available as a free service.
+                <!-- TAC lookup and native model are not available with a free resource key.
 
-                This means that you will first need a license key, which can be purchased
-                from our pricing page: http://51degrees.com/pricing. 
+                See https://51degrees.com/pricing to get a paid subscription with more properties.
 
-                Once this is done, a resource key with the properties required by this example
-                can be created at https://configure.51degrees.com/QKyYH5XT.
+                Once subscribed, a resource key with the properties required by this example
+                can be created at https://configure.51degrees.com/hYzn3TV3.
 
                 You can paste the resource key here, or set an environment
                 variable or System property called "SuperResourceKey"

--- a/shared/src/main/java/fiftyone/ipintelligence/examples/shared/DataFileHelper.java
+++ b/shared/src/main/java/fiftyone/ipintelligence/examples/shared/DataFileHelper.java
@@ -54,6 +54,13 @@ public class DataFileHelper {
      */
     public static final String ENTERPRISE_DATA_FILE_REL_PATH = "ip-intelligence-data/51Degrees-EnterpriseIpiV41.ipi";
 
+    /**
+     * Aligned name of the environment variable or system property which may
+     * hold an explicit path to the IP Intelligence data file. This name is
+     * checked first, before any search of the project space.
+     */
+    public static final String IPI_PATH_ENV_VAR = "51DEGREES_IPI_PATH";
+
 public static class DatafileInfo {
         FiftyOneDataFile fileInfo;
         String tier;
@@ -105,7 +112,10 @@ public static class DatafileInfo {
 
     public static void cantFindDataFile(String dataFile) {
         logger.error("Could not find the data file '{}' which must be " +
-                "somewhere in the project space to be found.", dataFile);
+                "somewhere in the project space to be found. An explicit " +
+                "path to the data file can be supplied via the {} " +
+                "environment variable or system property.",
+                dataFile, IPI_PATH_ENV_VAR);
     }
 
     /**
@@ -133,16 +143,37 @@ public static class DatafileInfo {
 
     /**
      * Tries to find the passed file, or if null a default file. Handles both absolute and relative paths.
+     * An absolute path supplied by the caller is used as is. Otherwise an
+     * explicit path supplied via the {@link #IPI_PATH_ENV_VAR} environment
+     * variable or system property is checked before the folder hierarchy is
+     * searched for the passed filename.
      * @param dataFilename a filename to find (can be absolute or relative path)
      * @return a full pathname
      * @throws Exception if the file was not found
      */
     @SuppressWarnings("RedundantThrows")
     public static String getDataFileLocation(String dataFilename) throws Exception {
+        // an explicit path supplied via the aligned environment variable or
+        // system property is checked before any search for the filename
+        if (Objects.isNull(dataFilename) ||
+                Paths.get(dataFilename).isAbsolute() == false) {
+            String envDataFile = System.getenv(IPI_PATH_ENV_VAR);
+            if (Objects.isNull(envDataFile)) {
+                envDataFile = System.getProperty(IPI_PATH_ENV_VAR);
+            }
+            if (Objects.nonNull(envDataFile)) {
+                if (Files.exists(Paths.get(envDataFile))) {
+                    return envDataFile;
+                }
+                logger.warn("Ignoring {} value '{}' as no file exists there",
+                        IPI_PATH_ENV_VAR, envDataFile);
+            }
+        }
+
         if (Objects.isNull(dataFilename)) {
             dataFilename = ENTERPRISE_DATA_FILE_REL_PATH;
         }
-        
+
         // Check if it's an absolute path
         Path dataPath = Paths.get(dataFilename);
         if (dataPath.isAbsolute()) {
@@ -167,8 +198,10 @@ public static class DatafileInfo {
                         return dataPath.toAbsolutePath().toString();
                     }
                     DataFileHelper.cantFindDataFile(dataFilename);
-                    throw new IOException("Data file not found at relative path: " + dataFilename + 
-                                        ". Searched in project directories and current working directory.");
+                    throw new IOException("Data file not found at relative path: " + dataFilename +
+                                        ". Searched in project directories and current working directory." +
+                                        " An explicit path can be supplied via the " + IPI_PATH_ENV_VAR +
+                                        " environment variable.");
                 }
             }
         }

--- a/shared/src/main/java/fiftyone/ipintelligence/examples/shared/KeyHelper.java
+++ b/shared/src/main/java/fiftyone/ipintelligence/examples/shared/KeyHelper.java
@@ -51,9 +51,11 @@ public class KeyHelper {
 
     public static String getOrSetTestResourceKey(String value, boolean shouldThrow) {
         return getOrSetResourceKey(value, TEST_RESOURCE_KEY,
-            "A free resource key configured with the " +
-                "properties required by this example may be obtained from " +
-                "https://configure.51degrees.com/jqz435Nc ",
+            "A free resource key may be obtained from " +
+                "https://configure.51degrees.com/Wkqxf3Bs. A free key " +
+                "populates the free tier properties only. See " +
+                "https://51degrees.com/pricing to get a paid subscription " +
+                "with more properties.",
             shouldThrow);
     }
     public static String getOrSetTestResourceKey(String value) {
@@ -98,12 +100,13 @@ public class KeyHelper {
         return getOrSetSuperResourceKey(value, variablename, true);
     }
     public static String getOrSetSuperResourceKey(String value, String variablename, boolean shouldThrow) {
-        return getOrSetResourceKey(value, variablename, "TAC lookup and Native Model are not " +
-                "available as a free service.\nThis means " +
-                "that you will first need a license key, which can be purchased " +
-                "from our pricing page: https://51degrees.com/pricing. \nOnce this is " +
-                "done, a resource key with the properties required by this example " +
-                "can be created at https://configure.51degrees.com/QKyYH5XT. ",
+        return getOrSetResourceKey(value, variablename, "TAC lookup and native model are not " +
+                "available with a free resource key. " +
+                "See https://51degrees.com/pricing to get a paid subscription " +
+                "with more properties. " +
+                "Once subscribed, a resource key with the properties required " +
+                "by this example can be created at " +
+                "https://configure.51degrees.com/hYzn3TV3.",
             shouldThrow);
     }
 }

--- a/shared/src/main/java/fiftyone/ipintelligence/examples/shared/KeyHelper.java
+++ b/shared/src/main/java/fiftyone/ipintelligence/examples/shared/KeyHelper.java
@@ -29,6 +29,12 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 
 public class KeyHelper {
+    /**
+     * Aligned name of the environment variable or system property which may
+     * hold the resource key. This name is checked first, before the legacy
+     * {@link #TEST_RESOURCE_KEY} name.
+     */
+    public static final String RESOURCE_KEY_ENV_VAR = "51DEGREES_RESOURCE_KEY";
     public static final String TEST_RESOURCE_KEY = "TestResourceKey";
     static Logger logger = LoggerFactory.getLogger(KeyHelper.class);
 
@@ -55,23 +61,29 @@ public class KeyHelper {
     }
     /**
      * Obtain a resource key from the passed argument,
-     * from environment variable or from a property. Store
-     * as System Property TEST_RESOURCE_KEY
+     * from environment variable or from a property. The aligned
+     * {@link #RESOURCE_KEY_ENV_VAR} name is checked first, then the
+     * passed variable name. Store as System Property under the
+     * passed variable name.
      */
     public static String getOrSetResourceKey(String value, String variableName,
                                              String errorMessage,
                                              boolean shouldThrow) {
         if (Objects.isNull(value)) {
-            value = KeyUtils.getNamedKey(variableName);
-
+            // check the aligned name first, then the legacy name
+            value = KeyUtils.getNamedKey(RESOURCE_KEY_ENV_VAR);
+            if (Objects.isNull(value)) {
+                value = KeyUtils.getNamedKey(variableName);
+            }
         }
         if (KeyUtils.isInvalidKey(value)) {
             logger.error("\nTo access Cloud Services you must supply a " +
                     "\"ResourceKey\" in one of the following ways: \n - in the " +
                     "configuration file of an example,\n - as a command line parameter of a " +
                     "runnable example,\n - as an Environment Variable named \"\u001B[36m{}\u001B[0m\"," +
-                    "\n - as a System Property named \"\u001B[36m{}\u001B[0m\").", variableName,
-                    variableName);
+                    "\n - as a System Property named \"\u001B[36m{}\u001B[0m\" " +
+                    "(the legacy name \"\u001B[36m{}\u001B[0m\" is also still accepted).",
+                    RESOURCE_KEY_ENV_VAR, RESOURCE_KEY_ENV_VAR, variableName);
             logger.error(errorMessage);
             if (shouldThrow) {
                 throw new IllegalStateException("\"" + value + "\" is not a valid resource key");

--- a/shared/src/main/java/fiftyone/ipintelligence/examples/shared/PropertyHelper.java
+++ b/shared/src/main/java/fiftyone/ipintelligence/examples/shared/PropertyHelper.java
@@ -27,14 +27,32 @@ import fiftyone.pipeline.core.data.WktString;
 import fiftyone.pipeline.engines.data.AspectPropertyValue;
 import fiftyone.pipeline.engines.data.AspectPropertyValueDefault;
 import fiftyone.pipeline.engines.exceptions.PropertyMissingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 
 public class PropertyHelper {
+
+    /**
+     * Advisory logged once when a property has no value, as this is
+     * commonly because the resource key in use does not include the
+     * property.
+     */
+    public static final String PRICING_MESSAGE = "Some properties used " +
+            "by this example are not available with a free resource key. " +
+            "See https://51degrees.com/pricing to get a paid subscription " +
+            "with more properties.";
+
+    static Logger logger = LoggerFactory.getLogger(PropertyHelper.class);
+
+    private static final AtomicBoolean pricingMessageLogged =
+            new AtomicBoolean(false);
 
     /**
      * Unwrap a value that may be a List of IWeightedValue at runtime
@@ -65,6 +83,21 @@ public class PropertyHelper {
         return value != null ? value.toString() : "Unknown";
     }
     /**
+     * Build the "no value" output for a property and log the
+     * {@link #PRICING_MESSAGE} advisory the first time any property
+     * has no value.
+     * @param property the property value, may be null
+     * @return a string describing why no value is available
+     */
+    private static String reportNoValue(AspectPropertyValue<?> property) {
+        if (pricingMessageLogged.compareAndSet(false, true)) {
+            logger.warn(PRICING_MESSAGE);
+        }
+        String message = property != null ? property.getNoValueMessage() : "No data available";
+        return "Unknown. " + message;
+    }
+
+    /**
      * Try to carry out a 'get' on a property getter, and catch a
      * {@link PropertyMissingException} to avoid the example breaking if the
      * resource key, or data file are not configured correctly by the user.
@@ -92,8 +125,7 @@ public class PropertyHelper {
      */
     public static String asStringProperty(AspectPropertyValue<String> property) {
         if (property == null || !property.hasValue()) {
-            String message = property != null ? property.getNoValueMessage() : "No data available";
-            return "Unknown. " + message;
+            return reportNoValue(property);
         } else {
             return unwrapValue(property.getValue());
         }
@@ -105,8 +137,7 @@ public class PropertyHelper {
      */
     public static String asIntegerProperty(AspectPropertyValue<Integer> property) {
         if (property == null || !property.hasValue()) {
-            String message = property != null ? property.getNoValueMessage() : "No data available";
-            return "Unknown. " + message;
+            return reportNoValue(property);
         } else {
             return unwrapValue(property.getValue());
         }
@@ -118,8 +149,7 @@ public class PropertyHelper {
      */
     public static String asFloatProperty(AspectPropertyValue<Float> property) {
         if (property == null || !property.hasValue()) {
-            String message = property != null ? property.getNoValueMessage() : "No data available";
-            return "Unknown. " + message;
+            return reportNoValue(property);
         } else {
             return unwrapValue(property.getValue());
         }
@@ -131,8 +161,7 @@ public class PropertyHelper {
      */
     public static String asIPAddressProperty(AspectPropertyValue<java.net.InetAddress> property) {
         if (property == null || !property.hasValue()) {
-            String message = property != null ? property.getNoValueMessage() : "No data available";
-            return "Unknown. " + message;
+            return reportNoValue(property);
         } else {
             return unwrapValue(property.getValue());
         }
@@ -144,8 +173,7 @@ public class PropertyHelper {
      */
     public static String asWktStringProperty(AspectPropertyValue<WktString> property) {
         if (property == null || !property.hasValue()) {
-            String message = property != null ? property.getNoValueMessage() : "No data available";
-            return "Unknown. " + message;
+            return reportNoValue(property);
         } else {
             return unwrapValue(property.getValue());
         }

--- a/shared/src/main/java/fiftyone/ipintelligence/examples/shared/settings.xml
+++ b/shared/src/main/java/fiftyone/ipintelligence/examples/shared/settings.xml
@@ -43,9 +43,12 @@ your IDE launch configuration or your operating system shell.
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <!-- a resource key configured for executing the tests and
-                examples in this source distribution may be configured at
-                https://configure.51degrees.com/jqz435Nc -->
+                <!-- a free resource key for executing the tests and
+                examples in this source distribution may be created at
+                https://configure.51degrees.com/Wkqxf3Bs. A free key
+                populates the free tier properties only. A key that also
+                includes the paid properties used by the examples may be
+                created at https://configure.51degrees.com/hYzn3TV3. -->
                 <TestResourceKey><!-- your resource key --></TestResourceKey>
             </properties>
         </profile>

--- a/web/getting-started.mixed/src/main/java/fiftyone/ipintelligence/examples/web/GettingStartedWebMixed.java
+++ b/web/getting-started.mixed/src/main/java/fiftyone/ipintelligence/examples/web/GettingStartedWebMixed.java
@@ -68,6 +68,7 @@ import java.util.Map;
 
 import static fiftyone.common.testhelpers.LogbackHelper.configureLogback;
 import static fiftyone.ipintelligence.examples.shared.DataFileHelper.ENTERPRISE_DATA_FILE_REL_PATH;
+import static fiftyone.ipintelligence.examples.shared.DataFileHelper.IPI_PATH_ENV_VAR;
 import static fiftyone.ipintelligence.examples.shared.PropertyHelper.*;
 import static fiftyone.pipeline.util.FileFinder.getFilePath;
 
@@ -113,7 +114,9 @@ public class GettingStartedWebMixed extends HttpServlet {
             System.setProperty("TestDataFile", ipiPath);
             logger.info("Using IP Intelligence data file: {}", ipiPath);
         } catch (Exception e) {
-            logger.warn("IP Intelligence data file not found at: {}", ipiDataFile);
+            logger.warn("IP Intelligence data file not found at: {}. " +
+                    "An explicit path can be supplied via the {} environment variable.",
+                    ipiDataFile, IPI_PATH_ENV_VAR);
             logger.warn("Will attempt to use default path from XML configuration");
             logger.debug("Error finding IP Intelligence data file", e);
         }

--- a/web/getting-started.onprem/src/main/java/fiftyone/ipintelligence/examples/web/GettingStartedWebOnPrem.java
+++ b/web/getting-started.onprem/src/main/java/fiftyone/ipintelligence/examples/web/GettingStartedWebOnPrem.java
@@ -78,6 +78,7 @@ import java.util.Map;
 
 import static fiftyone.common.testhelpers.LogbackHelper.configureLogback;
 import static fiftyone.ipintelligence.examples.shared.DataFileHelper.ENTERPRISE_DATA_FILE_REL_PATH;
+import static fiftyone.ipintelligence.examples.shared.DataFileHelper.IPI_PATH_ENV_VAR;
 import static fiftyone.ipintelligence.examples.shared.PropertyHelper.asStringProperty;
 import static fiftyone.ipintelligence.examples.shared.PropertyHelper.asIntegerProperty;
 import static fiftyone.ipintelligence.examples.shared.PropertyHelper.asFloatProperty;
@@ -120,7 +121,9 @@ public class GettingStartedWebOnPrem extends HttpServlet {
             System.setProperty("TestDataFile", dataFilePath);
             logger.info("Using data file: {}", dataFilePath);
         } catch (Exception e) {
-            logger.warn("Data file not found at expected location: {}", dataFile);
+            logger.warn("Data file not found at expected location: {}. " +
+                    "An explicit path can be supplied via the {} environment variable.",
+                    dataFile, IPI_PATH_ENV_VAR);
             logger.warn("Will attempt to use default path from XML configuration");
             logger.debug("Error finding data file", e);
         }


### PR DESCRIPTION
## Summary

This change aligns the environment variable names used by the examples with the convention shared across 51Degrees repositories.

- `KeyHelper` checks the aligned `51DEGREES_RESOURCE_KEY` name first as an environment variable or system property. The legacy `TestResourceKey` and `SuperResourceKey` names are retained and checked second, so existing setups keep working.
- `DataFileHelper` checks the `51DEGREES_IPI_PATH` name for an explicit data file path before searching the project space. An absolute path supplied on the command line still wins. The `TestDataFile` system property and the XML placeholders are unchanged.
- Developer-facing messages now reference the aligned names and the README documents the resolution order.

## Notes

- GitHub workflow secret references are unchanged. An accompanying issue advises on the aligned secret naming.
- The aligned names start with a digit, which POSIX shells do not accept in plain assignments. On Linux and macOS set them with the env command or pass them as system properties, for example `mvn exec:java -D51DEGREES_RESOURCE_KEY=AAA`.
