### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 51Degrees IP Intelligence Engines - Examples
 
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=java-open-source "Data rewards the curious") **Java IP Intelligence**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-java-examples&utm_content=readme.md&utm_term=51degrees-ip-intelligence-engines-examples "Data rewards the curious") **Java IP Intelligence**
 
-[Developer Documentation](https://51degrees.com/ip-intelligence-java/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=java-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/ip-intelligence-java/index.html?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-java-examples&utm_content=readme.md&utm_term=51degrees-ip-intelligence-engines-examples "developer documentation")
 
 ## Introduction
 
@@ -68,9 +68,9 @@ documentation now reflect what is free and what needs a paid subscription.
   and AccuracyRadiusMin.
 
 A free resource key selecting the free tier properties can be created at
-https://configure.51degrees.com/Wkqxf3Bs. A resource key that also includes
+https://configure.51degrees.com/Wkqxf3Bs?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-java-examples&utm_content=readme.md&utm_term=cloud-coming-soon. A resource key that also includes
 the paid properties used by the examples can be created at
-https://configure.51degrees.com/hYzn3TV3. See https://51degrees.com/pricing
+https://configure.51degrees.com/hYzn3TV3?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-java-examples&utm_content=readme.md&utm_term=cloud-coming-soon. See https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-java-examples&utm_content=readme.md&utm_term=cloud-coming-soon
 to get a paid subscription with more properties.
 
 ### On-Premise

--- a/console/src/main/java/fiftyone/ipintelligence/examples/console/GettingStartedOnPrem.java
+++ b/console/src/main/java/fiftyone/ipintelligence/examples/console/GettingStartedOnPrem.java
@@ -34,7 +34,7 @@
  * This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-java-examples/blob/main/console/src/main/java/fiftyone/ipintelligence/examples/console/GettingStartedOnPrem.java).
  * 
  * This example requires an enterprise IP Intelligence data file (.ipi).
- * To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us).
+ * To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=console-src-main-java-fiftyone-ipintelligence-examples-console-gettingstartedonprem.java&utm_term=header).
  * 
  * Required Maven Dependencies:
  * - [com.51degrees:ip-intelligence](https://central.sonatype.com/artifact/com.51degrees/ip-intelligence)
@@ -96,7 +96,7 @@ public class GettingStartedOnPrem {
     For production use, you will eventually need to use a Distributor service and license key
     to keep your data file updated.
     
-    To obtain access to enterprise data files for hosting, please contact us: https://51degrees.com/contact-us */
+    To obtain access to enterprise data files for hosting, please contact us: https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=console-src-main-java-fiftyone-ipintelligence-examples-console-gettingstartedonprem.java&utm_term=main */
 
     public static void main(String[] args) throws Exception {
         configureLogback(getFilePath("logback.xml"));
@@ -130,7 +130,7 @@ public class GettingStartedOnPrem {
                     "Please provide a valid path to an IP Intelligence data file (.ipi). " +
                     "An explicit path can be supplied via the {} environment variable. " +
                     "For testing, you can obtain an enterprise data file by contacting us at " +
-                    "https://51degrees.com/contact-us",
+                    "https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=console-src-main-java-fiftyone-ipintelligence-examples-console-gettingstartedonprem.java&utm_term=data-file-not-found",
                     dataFile, DataFileHelper.IPI_PATH_ENV_VAR);
             throw e;
         }
@@ -139,7 +139,7 @@ public class GettingStartedOnPrem {
         options contained in the file "gettingStartedOnPrem.xml".
 
         For more information about pipelines in general see the documentation at
-        http://51degrees.com/documentation/_concepts__configuration__builders__index.html
+        https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=console-src-main-java-fiftyone-ipintelligence-examples-console-gettingstartedonprem.java&utm_term=run
 
         Note that we wrap the creation of a pipeline in a try/resources to control its lifecycle */
         // the configuration file is in the resources directory
@@ -207,7 +207,7 @@ public class GettingStartedOnPrem {
             IPIntelligenceData ipData = data.get(IPIntelligenceData.class);
 
             /* Display the results of the detection, which are called IP Intelligence properties. See the
-            property dictionary at https://51degrees.com/developers/property-dictionary for
+            property dictionary at https://51degrees.com/developers/property-dictionary?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=console-src-main-java-fiftyone-ipintelligence-examples-console-gettingstartedonprem.java&utm_term=analyzeevidence for
             details of all available properties. */
             
             // Output all the properties using shared PropertyHelper methods

--- a/console/src/main/java/fiftyone/ipintelligence/examples/console/MetadataOnPrem.java
+++ b/console/src/main/java/fiftyone/ipintelligence/examples/console/MetadataOnPrem.java
@@ -55,7 +55,7 @@ import static fiftyone.ipintelligence.examples.shared.DataFileHelper.ENTERPRISE_
  * - [com.51degrees:ip-intelligence](https://central.sonatype.com/artifact/com.51degrees/ip-intelligence)
  *
  * This example requires an enterprise IP Intelligence data file (.ipi).
- * To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us).
+ * To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=console-src-main-java-fiftyone-ipintelligence-examples-console-metadataonprem.java&utm_term=header).
  */
 public class MetadataOnPrem {
     private static final Logger logger = LoggerFactory.getLogger(GettingStartedOnPrem.class);
@@ -63,7 +63,7 @@ public class MetadataOnPrem {
     /* In this example, by default, the 51degrees IP Intelligence data file needs to be somewhere in the project
     space, or you may specify another file as a command line parameter.
 
-    For testing, contact us to obtain an enterprise data file: https://51degrees.com/contact-us */
+    For testing, contact us to obtain an enterprise data file: https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=console-src-main-java-fiftyone-ipintelligence-examples-console-metadataonprem.java&utm_term=main */
 
     public static void main(String[] args) throws Exception {
         configureLogback(getFilePath("logback.xml"));

--- a/console/src/main/java/fiftyone/ipintelligence/examples/console/OfflineProcessing.java
+++ b/console/src/main/java/fiftyone/ipintelligence/examples/console/OfflineProcessing.java
@@ -38,7 +38,7 @@
  * This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-java-examples/blob/main/console/src/main/java/fiftyone/ipintelligence/examples/console/OfflineProcessing.java).
  *
  * This example requires an enterprise IP Intelligence data file (.ipi).
- * To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us).
+ * To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=console-src-main-java-fiftyone-ipintelligence-examples-console-offlineprocessing.java&utm_term=header).
  *
  * Required Maven Dependencies:
  * - [com.51degrees:ip-intelligence](https://central.sonatype.com/artifact/com.51degrees/ip-intelligence)
@@ -95,7 +95,7 @@ public class OfflineProcessing {
     // This 51degrees IP Intelligence data file (distributed with the source) needs to
     // be somewhere in the project space
     //
-    // For testing, contact us to obtain an enterprise data file: https://51degrees.com/contact-us
+    // For testing, contact us to obtain an enterprise data file: https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=console-src-main-java-fiftyone-ipintelligence-examples-console-offlineprocessing.java&utm_term=datadir
     private static final String dataDir = "ip-intelligence-data";
     // This 51degrees file of 20,000 examples (distributed with the source)
     // needs to be somewhere in the project space. Additional evidence files
@@ -242,7 +242,7 @@ public class OfflineProcessing {
                             "limited properties and is of limited accuracy");
                     logger.info("The example requires an Enterprise data file " +
                             "to work fully. Find out about the Enterprise " +
-                            "data file here: https://51degrees.com/pricing");
+                            "data file here: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=console-src-main-java-fiftyone-ipintelligence-examples-console-offlineprocessing.java&utm_term=enterprise-data-file");
                 }
             }
         }

--- a/console/src/main/java/fiftyone/ipintelligence/examples/console/PerformanceBenchmark.java
+++ b/console/src/main/java/fiftyone/ipintelligence/examples/console/PerformanceBenchmark.java
@@ -35,7 +35,7 @@
  * This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-java-examples/blob/main/console/src/main/java/fiftyone/ipintelligence/examples/console/PerformanceBenchmark.java).
  *
  * This example requires an enterprise IP Intelligence data file (.ipi).
- * To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us).
+ * To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=console-src-main-java-fiftyone-ipintelligence-examples-console-performancebenchmark.java&utm_term=header).
  *
  * Required Maven Dependencies:
  * - [com.51degrees:ip-intelligence](https://central.sonatype.com/artifact/com.51degrees/ip-intelligence)

--- a/console/src/main/java/fiftyone/ipintelligence/examples/console/UpdateDataFile.java
+++ b/console/src/main/java/fiftyone/ipintelligence/examples/console/UpdateDataFile.java
@@ -70,7 +70,7 @@ import static fiftyone.pipeline.util.FileFinder.getFilePath;
  * to keep your data file updated. However, for now this example requires a custom URL where
  * an updated data file will be hosted.
  * 
- * To obtain access to enterprise data files, please [contact us](https://51degrees.com/contact-us).
+ * To obtain access to enterprise data files, please [contact us](https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=console-src-main-java-fiftyone-ipintelligence-examples-console-updatedatafile.java&utm_term=header).
  *
  * ## Configuration
  * - the pipeline must be configured to use a temp file
@@ -161,7 +161,7 @@ import static fiftyone.pipeline.util.FileFinder.getFilePath;
  * For production use, you will eventually need to use a Distributor service and license key
  * to keep your data file updated.
  * 
- * To obtain access to enterprise data files for hosting, please [contact us](https://51degrees.com/contact-us).
+ * To obtain access to enterprise data files for hosting, please [contact us](https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=console-src-main-java-fiftyone-ipintelligence-examples-console-updatedatafile.java&utm_term=header-2).
  *
  */
 
@@ -181,7 +181,7 @@ import static fiftyone.pipeline.util.FileFinder.getFilePath;
  * to keep your data file updated. However, for now this example requires a custom URL where
  * an updated data file will be hosted.
  * 
- * To obtain access to enterprise data files, please <a href="https://51degrees.com/contact-us">contact us</a>.
+ * To obtain access to enterprise data files, please <a href="https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-java-examples&amp;utm_content=console-src-main-java-fiftyone-ipintelligence-examples-console-updatedatafile.java&amp;utm_term=updatedatafile">contact us</a>.
  * This license key must be supplied as a command line argument or by setting
  * an environment variable or system property called {@link UpdateDataFile#UPDATE_EXAMPLE_LICENSE_KEY_NAME}
  */
@@ -225,7 +225,7 @@ public class UpdateDataFile {
             logger.error("For production use, you will eventually need to use a Distributor service and " +
                     "license key to keep your data file updated. However, for now this example requires " +
                     "a custom URL where an updated data file will be hosted. To obtain access to enterprise " +
-                    "data files, please contact us at https://51degrees.com/contact-us. You must supply the " +
+                    "data files, please contact us at https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=console-src-main-java-fiftyone-ipintelligence-examples-console-updatedatafile.java&utm_term=license-key-required. You must supply the " +
                     "license key as an argument to this program, or as an environment or system variable " +
                     "named '{}'", UPDATE_EXAMPLE_LICENSE_KEY_NAME);
             throw new IllegalArgumentException("No license key available");
@@ -308,7 +308,7 @@ public class UpdateDataFile {
                     // For production use, you will eventually need to use a Distributor service and
                     // license key to keep your data file updated. However, for now this example
                     // requires a custom URL where an updated data file will be hosted.
-                    // To obtain access to enterprise data files, please contact us at https://51degrees.com/contact-us
+                    // To obtain access to enterprise data files, please contact us at https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=console-src-main-java-fiftyone-ipintelligence-examples-console-updatedatafile.java&utm_term=run
                     .setDataUpdateLicenseKey(licenseKey)
                     // Enable update on startup, the auto update system
                     // will be used to check for an update before the

--- a/console/src/main/resources/tacCloud.xml
+++ b/console/src/main/resources/tacCloud.xml
@@ -26,10 +26,10 @@
             <BuildParameters>
                 <!-- TAC lookup and native model are not available with a free resource key.
 
-                See https://51degrees.com/pricing to get a paid subscription with more properties.
+                See https://51degrees.com/pricing?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=ip-intelligence-java-examples&amp;utm_content=console-src-main-resources-taccloud.xml&amp;utm_term=buildparameters to get a paid subscription with more properties.
 
                 Once subscribed, a resource key with the properties required by this example
-                can be created at https://configure.51degrees.com/hYzn3TV3.
+                can be created at https://configure.51degrees.com/hYzn3TV3?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=ip-intelligence-java-examples&amp;utm_content=console-src-main-resources-taccloud.xml&amp;utm_term=buildparameters.
 
                 You can paste the resource key here, or set an environment
                 variable or System property called "SuperResourceKey"

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <packaging>pom</packaging>
 
     <name>51Degrees :: IP Intelligence :: Examples</name>
-    <url>https://51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=ip-intelligence-java-examples&amp;utm_content=pom.xml&amp;utm_term=url
     <description>IP Intelligence examples</description>
 
     <modules>

--- a/shared/src/main/java/fiftyone/ipintelligence/examples/shared/DataFileHelper.java
+++ b/shared/src/main/java/fiftyone/ipintelligence/examples/shared/DataFileHelper.java
@@ -101,7 +101,7 @@ public static class DatafileInfo {
                     "This is used for illustration, and has limited " +
                     "accuracy and capabilities. Find out about the " +
                     "Enterprise data file on our pricing page: " +
-                    "https://51degrees.com/pricing");
+                    "https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=shared-src-main-java-fiftyone-ipintelligence-examples-shared-datafilehelper.java&utm_term=lite-data-file");
         }
         if (daysOld > 28) {
             logger.warn("This example is using a data file that is more " +

--- a/shared/src/main/java/fiftyone/ipintelligence/examples/shared/KeyHelper.java
+++ b/shared/src/main/java/fiftyone/ipintelligence/examples/shared/KeyHelper.java
@@ -52,9 +52,9 @@ public class KeyHelper {
     public static String getOrSetTestResourceKey(String value, boolean shouldThrow) {
         return getOrSetResourceKey(value, TEST_RESOURCE_KEY,
             "A free resource key may be obtained from " +
-                "https://configure.51degrees.com/Wkqxf3Bs. A free key " +
+                "https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=shared-src-main-java-fiftyone-ipintelligence-examples-shared-keyhelper.java&utm_term=resource-key-required. A free key " +
                 "populates the free tier properties only. See " +
-                "https://51degrees.com/pricing to get a paid subscription " +
+                "https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=shared-src-main-java-fiftyone-ipintelligence-examples-shared-keyhelper.java&utm_term=resource-key-required to get a paid subscription " +
                 "with more properties.",
             shouldThrow);
     }
@@ -102,11 +102,11 @@ public class KeyHelper {
     public static String getOrSetSuperResourceKey(String value, String variablename, boolean shouldThrow) {
         return getOrSetResourceKey(value, variablename, "TAC lookup and native model are not " +
                 "available with a free resource key. " +
-                "See https://51degrees.com/pricing to get a paid subscription " +
+                "See https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=shared-src-main-java-fiftyone-ipintelligence-examples-shared-keyhelper.java&utm_term=super-resource-key-required to get a paid subscription " +
                 "with more properties. " +
                 "Once subscribed, a resource key with the properties required " +
                 "by this example can be created at " +
-                "https://configure.51degrees.com/hYzn3TV3.",
+                "https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=shared-src-main-java-fiftyone-ipintelligence-examples-shared-keyhelper.java&utm_term=super-resource-key-required.",
             shouldThrow);
     }
 }

--- a/shared/src/main/java/fiftyone/ipintelligence/examples/shared/PropertyHelper.java
+++ b/shared/src/main/java/fiftyone/ipintelligence/examples/shared/PropertyHelper.java
@@ -46,7 +46,7 @@ public class PropertyHelper {
      */
     public static final String PRICING_MESSAGE = "Some properties used " +
             "by this example are not available with a free resource key. " +
-            "See https://51degrees.com/pricing to get a paid subscription " +
+            "See https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=shared-src-main-java-fiftyone-ipintelligence-examples-shared-propertyhelper.java&utm_term=pricing_message to get a paid subscription " +
             "with more properties.";
 
     static Logger logger = LoggerFactory.getLogger(PropertyHelper.class);
@@ -112,7 +112,7 @@ public class PropertyHelper {
             String message =
                     "The property '" + e.getPropertyName() + "' is not " +
                     "available in this data file. See data file options " +
-                    "<a href=\"https://51degrees.com/pricing\">here</a>";
+                    "<a href=\"https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=shared-src-main-java-fiftyone-ipintelligence-examples-shared-propertyhelper.java&utm_term=property-missing\">here</a>";
             AspectPropertyValue<T> result = new AspectPropertyValueDefault<>();
             result.setNoValueMessage(message);
             return result;

--- a/shared/src/main/java/fiftyone/ipintelligence/examples/shared/settings.xml
+++ b/shared/src/main/java/fiftyone/ipintelligence/examples/shared/settings.xml
@@ -45,10 +45,10 @@ your IDE launch configuration or your operating system shell.
             <properties>
                 <!-- a free resource key for executing the tests and
                 examples in this source distribution may be created at
-                https://configure.51degrees.com/Wkqxf3Bs. A free key
+                https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-java-examples&amp;utm_content=shared-src-main-java-fiftyone-ipintelligence-examples-shared-settings.xml&amp;utm_term=properties. A free key
                 populates the free tier properties only. A key that also
                 includes the paid properties used by the examples may be
-                created at https://configure.51degrees.com/hYzn3TV3. -->
+                created at https://configure.51degrees.com/hYzn3TV3?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-java-examples&amp;utm_content=shared-src-main-java-fiftyone-ipintelligence-examples-shared-settings.xml&amp;utm_term=properties. -->
                 <TestResourceKey><!-- your resource key --></TestResourceKey>
             </properties>
         </profile>

--- a/web/getting-started.onprem/src/main/java/fiftyone/ipintelligence/examples/web/GettingStartedWebOnPrem.java
+++ b/web/getting-started.onprem/src/main/java/fiftyone/ipintelligence/examples/web/GettingStartedWebOnPrem.java
@@ -34,7 +34,7 @@
  * This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-java-examples/blob/master/web/getting-started.onprem/src/main/java/fiftyone/ipintelligence/examples/web/GettingStartedWebOnPrem.java).
  *
  * This example requires an enterprise IP Intelligence data file (.ipi). 
- * To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us).
+ * To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=web-getting-started.onprem-src-main-java-fiftyone-ipintelligence-examples-web-gettingstartedwebonprem.java&utm_term=header).
  *
  * Required Maven Dependencies:
  * - [com.51degrees:ip-intelligence](https://central.sonatype.com/artifact/com.51degrees/ip-intelligence)
@@ -102,7 +102,7 @@ import static fiftyone.pipeline.util.FileFinder.getFilePath;
  * The configuration file for the pipeline is at src/main/webapp/WEB-INF/51Degrees-OnPrem.xml
  * 
  * This example requires an enterprise IP Intelligence data file (.ipi). 
- * To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us).
+ * To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=web-getting-started.onprem-src-main-java-fiftyone-ipintelligence-examples-web-gettingstartedwebonprem.java&utm_term=gettingstartedwebonprem).
  */
 public class GettingStartedWebOnPrem extends HttpServlet {
     private static final long serialVersionUID = 1734154705981153540L;

--- a/web/shared/src/main/java/fiftyone/ipintelligence/examples/web/HtmlContentHelper.java
+++ b/web/shared/src/main/java/fiftyone/ipintelligence/examples/web/HtmlContentHelper.java
@@ -216,7 +216,7 @@ public class HtmlContentHelper {
                 "you are using a Lite data file included with this source distribution.\n" +
                 "<p>The example requires an Enterprise data file to work fully. " +
                 "You can get the Enterprise data file " +
-                "<a href='https://51degrees.com/pricing'>here</a></div>\n");
+                "<a href='https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=web-shared-src-main-java-fiftyone-ipintelligence-examples-web-htmlcontenthelper.java&utm_term=lite-data-file'>here</a></div>\n");
     }
 
     public static void doHtmlPostamble(PrintWriter out) {


### PR DESCRIPTION
## Summary

Every navigational 51degrees.com and configure.51degrees.com link in this repository now carries the standard UTM query string so the Content Team can trace Matomo campaign traffic to the exact repository, file, and location it came from:

`?utm_source=<github|code|nuget|npm|maven|packagist>&utm_medium=<readme|docs|example|comment|package>&utm_campaign=<repository>&utm_content=<file slug>&utm_term=<location in file>`

30 links across 15 files, in-place URL replacements only. While tagging, http, www, and protocol-relative variants were normalised to https on the bare domain, pre-2026 utm schemes were replaced, and the retired Logo.ashx banner URL was replaced with img/logo.png where present. Functional endpoints (cloud, distributor, devices-v4, bulkdata), test fixtures, license headers, and generated files are untouched.

## Lint

A second commit adds the utm-link-lint workflow, which runs the shared script from 51Degrees/common-ci on pull requests and pushes to main, keeping the convention enforced from now on. The lint check on this PR stays red until 51Degrees/common-ci#207 merges, since the workflow fetches the script from that repository's main.

The full convention is documented in UTM-LINK-TAGGING.md in 51Degrees/internal-common-ci (PR 3).