### PR TITLE
FEAT: Show stale data-file warning on on-premise web example pages.

### DIFF
--- a/web/getting-started.mixed/src/main/java/fiftyone/ipintelligence/examples/web/GettingStartedWebMixed.java
+++ b/web/getting-started.mixed/src/main/java/fiftyone/ipintelligence/examples/web/GettingStartedWebMixed.java
@@ -191,7 +191,7 @@ public class GettingStartedWebMixed extends HttpServlet {
                                             IPIntelligenceData ipiData, String inputIp,
                                             FlowData flowData) {
         return template
-            .replace("${DATA_FILE_WARNING}", "")
+            .replace("${DATA_FILE_WARNING}", HtmlContentHelper.getDataFileAgeWarning(flowData))
             .replace("${INPUT_IP_ADDRESS}", inputIp != null ? inputIp : "")
             // Device Detection properties
             .replace("${HARDWARE_VENDOR}", asString(tryGet(deviceData::getHardwareVendor)))

--- a/web/getting-started.onprem/src/main/java/fiftyone/ipintelligence/examples/web/GettingStartedWebOnPrem.java
+++ b/web/getting-started.onprem/src/main/java/fiftyone/ipintelligence/examples/web/GettingStartedWebOnPrem.java
@@ -208,7 +208,7 @@ public class GettingStartedWebOnPrem extends HttpServlet {
      */
     private String substituteTemplateValues(String template, IPIntelligenceData ipiData, String inputIp, FlowData flowData) {
         return template
-            .replace("${DATA_FILE_WARNING}", "")
+            .replace("${DATA_FILE_WARNING}", HtmlContentHelper.getDataFileAgeWarning(flowData))
             .replace("${INPUT_IP_ADDRESS}", inputIp != null ? inputIp : "")
             .replace("${REGISTERED_NAME}", asStringProperty(tryGet(ipiData::getRegisteredName)))
             .replace("${REGISTERED_OWNER}", asStringProperty(tryGet(ipiData::getRegisteredOwner)))

--- a/web/shared/src/main/java/fiftyone/ipintelligence/examples/web/HtmlContentHelper.java
+++ b/web/shared/src/main/java/fiftyone/ipintelligence/examples/web/HtmlContentHelper.java
@@ -22,7 +22,21 @@
 
 package fiftyone.ipintelligence.examples.web;
 
+import fiftyone.ipintelligence.engine.onpremise.flowelements.IPIntelligenceOnPremiseEngine;
+import fiftyone.pipeline.core.data.FlowData;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
 public class HtmlContentHelper {
+
+    /**
+     * The number of days after which an on-premise data file is considered old
+     * enough to warrant a warning on the example pages. Matches the threshold
+     * used by the other 51Degrees examples.
+     */
+    private static final long DATA_FILE_AGE_WARNING_DAYS = 28;
 
     /**
      * The contact-us message banner has two variants. The cloud variant invites
@@ -32,6 +46,40 @@ public class HtmlContentHelper {
     public enum ContactMessageVariant {
         CLOUD,
         ON_PREMISE
+    }
+
+    /**
+     * Build the stale-data-file warning shown at the top of the on-premise web
+     * example pages, mirroring the other 51Degrees examples. The warning is only
+     * rendered when an on-premise engine is present and its data file is more
+     * than {@link #DATA_FILE_AGE_WARNING_DAYS} days old. Cloud examples have no
+     * local data file, so they receive an empty string.
+     *
+     * @param flowData the flow data for the request, used to locate the
+     *                 on-premise engine and read its data file published date
+     * @return the warning markup, or an empty string when no warning is needed
+     */
+    public static String getDataFileAgeWarning(FlowData flowData) {
+        IPIntelligenceOnPremiseEngine engine =
+                flowData.getPipeline().getElement(IPIntelligenceOnPremiseEngine.class);
+        if (engine == null) {
+            // No on-premise engine (e.g. a cloud example) - nothing to warn about.
+            return "";
+        }
+        Date published = engine.getDataFilePublishedDate();
+        if (published == null) {
+            return "";
+        }
+        long daysOld = ChronoUnit.DAYS.between(published.toInstant(), Instant.now());
+        if (daysOld <= DATA_FILE_AGE_WARNING_DAYS) {
+            return "";
+        }
+        // language=html
+        return "<div class=\"c-eg-alert\">\n" +
+                "  The IP intelligence data file is " + daysOld + " days old. " +
+                "A more recent data file may be needed for the most accurate IP " +
+                "intelligence results.\n" +
+                "</div>";
     }
 
     /**

--- a/web/shared/src/main/java/fiftyone/ipintelligence/examples/web/HtmlContentHelper.java
+++ b/web/shared/src/main/java/fiftyone/ipintelligence/examples/web/HtmlContentHelper.java
@@ -63,7 +63,7 @@ public class HtmlContentHelper {
         IPIntelligenceOnPremiseEngine engine =
                 flowData.getPipeline().getElement(IPIntelligenceOnPremiseEngine.class);
         if (engine == null) {
-            // No on-premise engine (e.g. a cloud example) - nothing to warn about.
+            // No on-premise engine (e.g. a cloud example).
             return "";
         }
         Date published = engine.getDataFilePublishedDate();
@@ -78,7 +78,11 @@ public class HtmlContentHelper {
         return "<div class=\"c-eg-alert\">\n" +
                 "  The IP intelligence data file is " + daysOld + " days old. " +
                 "A more recent data file may be needed for the most accurate IP " +
-                "intelligence results.\n" +
+                "intelligence results. The latest Lite data file is available from the " +
+                "<a href=\"https://github.com/51Degrees/ip-intelligence-data\">ip-intelligence-data " +
+                "repository on GitHub</a>. Find out about the full Enterprise data file, " +
+                "which includes automatic daily updates, on our " +
+                "<a href=\"https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-java-examples&utm_content=web-shared-src-main-java-fiftyone-ipintelligence-examples-web-htmlcontenthelper.java&utm_term=data-file-age-warning\">pricing page</a>.\n" +
                 "</div>";
     }
 


### PR DESCRIPTION
Closes #99 

Add HtmlContentHelper.getDataFileAgeWarning(FlowData), which reads the on-premise engine's data file published date and returns a c-eg-alert banner when the file is more than 28 days old
Integrate the helper into getting-started.onprem and getting-started.mixed in place of the empty-string substitution, so the warning renders at the top of the page when the loaded data file is stale.